### PR TITLE
Add missing replyTo field in message options

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Currently the following fields are supported:
 | ------------- | ------------- |
 | from | Email address of the sender (e.g.'sender@example.com' or '"Sender Name" sender@server.com') |
 | to | Comma separated list or an array of recipients |
+| replyTo | Email address to which replies are sent |
 | cc | Comma separated list or an array of recipients |
 | bcc | Comma separated list or an array of recipients |
 | subject | Subject of the email |

--- a/lib/index.js
+++ b/lib/index.js
@@ -108,6 +108,7 @@ module.exports = {
 
           const msg = [
             'from',
+            'replyTo',
             'to',
             'cc',
             'bcc',


### PR DESCRIPTION
# Why?
It was impossible to change replyTo field while sending an email.

# Changes
I have added replyTo field to the config passed in sendMail call and updated readme to include replyTo in supported fields table